### PR TITLE
Fix the link to toucan

### DIFF
--- a/src/themes/default/templates/index.mustache
+++ b/src/themes/default/templates/index.mustache
@@ -57,7 +57,7 @@
     <p>We’re passionate about open-source, and that’s why <br>Toucan is free on GitHub — <strong>forever</strong>. </p>
     <p>As we gear up for a <u>fall release</u>, your feedback is invaluable in helping us perfect our static site generator for a cutting-edge web experience.</p>
     <p>⭐️</p>
-    <a class="cta" href="http://github.com/binarybirds/toucan/tree/dev/">GitHub repository</a>
+    <a class="cta" href="https://github.com/toucansites/toucan">GitHub repository</a>
     <p>Please, don't forget to give us a star.</p>
     <p>🙏</p>
     </div>


### PR DESCRIPTION
The link to toucan was returning a 404 error.
I have fixed the link to point to `toucansites/toucan`.