### PR TITLE
Add title property to author and tag types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .vscode
 .build
 /docs
+/docs-live
 /dist
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dist:
 	toucan generate . --target live
 
 diff:
-	diff --color=always -r docs-v4 docs --exclude=api || true
+	diff --color=always -r docs-live docs --exclude=api || true
 
 watch:
 	toucan watch .

--- a/contents/blog/authors/andris-sipos/index.md
+++ b/contents/blog/authors/andris-sipos/index.md
@@ -1,6 +1,6 @@
 ---
 type: author
-title: "Andris Sipos"
+name: "Andris Sipos"
 description: "Andris, a marketing and sales specialist, passionate about game development and project management."
 image: "./assets/andris-sipos.webp"
 order: 10

--- a/contents/blog/authors/ferenc-viasz-kadi/index.md
+++ b/contents/blog/authors/ferenc-viasz-kadi/index.md
@@ -1,6 +1,6 @@
 ---
 type: author
-title: "Ferenc Viasz-Kadi"
+name: "Ferenc Viasz-Kadi"
 description: "Former iOS Developer, co-founder of Binary Birds Kft."
 image: "./assets/ferenc-viasz-kadi.jpg"
 order: 10

--- a/contents/blog/authors/gabor-lengyel/index.md
+++ b/contents/blog/authors/gabor-lengyel/index.md
@@ -1,6 +1,6 @@
 ---
 type: author
-title: "Gábor Lengyel"
+name: "Gábor Lengyel"
 description: "Former Android Developer, co-founder of Binary Birds Kft."
 image: "./assets/gabor-lengyel.jpg"
 order: 10

--- a/contents/blog/authors/index.md
+++ b/contents/blog/authors/index.md
@@ -1,4 +1,5 @@
 ---
+type: page
 title: "Explore articles by authors."
 description: "Discover articles by authors and explore content from your favorite writers. Find insights and stories tailored to your interests."
 views:

--- a/contents/blog/authors/tibor-bodecs/index.md
+++ b/contents/blog/authors/tibor-bodecs/index.md
@@ -1,6 +1,6 @@
 ---
 type: author
-title: "Tibor Bödecs"
+name: "Tibor Bödecs"
 description: "Tibor is a member of the Swift Server Workgroup (SSWG), he is the co-founder of Binary Birds Kft."
 image: "./assets/tibor-bodecs.jpg"
 order: 10

--- a/contents/docs/[03]content-management/[02]content-types/index.md
+++ b/contents/docs/[03]content-management/[02]content-types/index.md
@@ -87,7 +87,7 @@ relations:
         references: author
         type: many
         order:
-            key: title
+            key: name
             direction: asc
     tags:
         references: tag

--- a/contents/docs/[03]content-management/[02]content-types/index.md
+++ b/contents/docs/[03]content-management/[02]content-types/index.md
@@ -43,10 +43,19 @@ The YAML file defines a content type with the following structure:
 
 When you create new content, the content type acts as its backbone. Each content type sets its own properties, relationships, and queries. The path and id help locate and identify each piece of content, making it easier to form relationships and query additional objects for every item.
 
-
 ## Properties
 
-For example, a blog post might include a `title`, `description`, `image`, `publication` date, and a flag to mark the article as `featured`. Here’s how you can represent these fields using the content type definition YAML file:
+Properties for a content type are declared under the `properties` field within the content type definition. Each property must define a `type`, which corresponds to a `PropertyType`.
+
+In addition to the type, you can optionally:
+- Mark the property as `required`.
+- Specify a `defaultValue` to be used when the property is not provided.
+
+Every property defined in the content type is automatically validated against the content’s front matter. If a property is marked as `required`, Toucan will emit a warning when the property is missing or contains invalid data.
+
+Properties are also queryable, allowing you to filter or retrieve content items based on their property values.
+
+### Example
 
 ```yaml
 properties:
@@ -69,11 +78,27 @@ properties:
     featured:
         type: bool
         required: false
-        default: false
+        defaultValue: false
 ```
 
-Each property defined in this section will be validated against the content’s front matter. If a property is marked as `required`, Toucan will warn you if it’s missing or invalid. Properties can also be used to query your content.
+### System Properties
 
+The following properties are automatically included in every content type in Toucan, regardless of whether you explicitly define them:
+- `id`: A unique identifier for the content.
+- `slug`: A URL-friendly string used to identify the object.
+- `type`: The associated `ContentType` for the content.
+- `lastUpdate`: A timestamp indicating when the object was last modified.
+
+These properties are required for the content generation process.
+
+By default, Toucan automatically assigns values to these properties. However, you can override `id`, `slug`, and `type` as needed. Overriding is most commonly used when explicitly specifying a `type` for your content.
+
+```yml
+---
+type: page
+title: "Toucan Examples"
+---
+```
 
 ## Relations
 
@@ -180,7 +205,7 @@ properties:
     featured:
         type: bool
         required: false
-        default: false
+        defaultValue: false
 
 relations:
     authors:

--- a/pipelines/html.yml
+++ b/pipelines/html.yml
@@ -47,7 +47,7 @@ queries:
         scope: detail
         limit: 12
         orderBy:
-            - key: title
+            - key: name
               direction: asc
     tags:
         contentType: tag

--- a/types/author.yml
+++ b/types/author.yml
@@ -3,7 +3,7 @@ paths:
     - blog/authors
 
 properties:
-    title:
+    name:
         type: string
         required: true
     image:

--- a/types/author.yml
+++ b/types/author.yml
@@ -1,8 +1,11 @@
 id: author
-path:
+paths:
     - blog/authors
 
 properties:
+    title:
+        type: string
+        required: true
     image:
         type: asset
         required: true

--- a/types/post.yml
+++ b/types/post.yml
@@ -19,7 +19,7 @@ relations:
         references: author
         type: many
         order:
-            key: title
+            key: name
             direction: asc
     tags:
         references: tag

--- a/types/tag.yml
+++ b/types/tag.yml
@@ -3,6 +3,9 @@ paths:
     - blog/tags
 
 properties:
+    title:
+        type: string
+        required: true
     order:
         type: int
         required: true


### PR DESCRIPTION
Introduces a required 'title' property to both author and tag YAML type definitions. Updates .gitignore and Makefile to support 'docs-live' directory. Adds 'type: page' to authors index markdown for improved metadata.