### PR TITLE
Add CTA block and update contact page to use it

### DIFF
--- a/blocks/cta.yml
+++ b/blocks/cta.yml
@@ -1,0 +1,12 @@
+name: cta
+tag: a
+removesChildParagraph: true
+parameters:
+  - label: email
+  - label: class
+    defaultValue: "cta"
+attributes:
+  - name: href
+    value: "mailto:{{email}}"
+  - name: class
+    value: "{{class}}"

--- a/contents/contact/index.md
+++ b/contents/contact/index.md
@@ -7,6 +7,4 @@ description: "Have questions about Toucan, the Markdown-based static site genera
 
 Reach out with any questions about Toucan, the Markdown-based static site generator. Feel free to send an inquiry if you’re looking to build a website with Toucan.
 
-<a href="mailto:support@binarybirds.com" class="cta">Contact us</a>
-
-
+@CTA(email: "support@binarybirds.com") { Contact us }

--- a/templates/default/assets/css/base.css
+++ b/templates/default/assets/css/base.css
@@ -61,7 +61,6 @@ p {
     font-size: 1.5rem;
     line-height: 2rem;
     margin-top: 16px;
-    margin-bottom: 32px;
     color: var(--text-color-2);
     margin-bottom: 32px;
 }


### PR DESCRIPTION
Introduced a new 'cta' block in blocks/cta.yml for reusable call-to-action links. Updated the contact page to use the new CTA block instead of a hardcoded anchor tag. Also cleaned up duplicate margin-bottom property in base.css.