### PR TITLE
Update links to source page in installation docs

### DIFF
--- a/contents/docs/[01]installation/[01]macos/index.md
+++ b/contents/docs/[01]installation/[01]macos/index.md
@@ -98,4 +98,4 @@ toucan --help
 
 ## Compile from source
 
-For instructions on compiling from source, see [Compile from source](/docs/installation/compile-from-source/).
+For instructions on compiling from source, see [Compile from source](/docs/installation/source/).

--- a/contents/docs/[01]installation/[02]linux/index.md
+++ b/contents/docs/[01]installation/[02]linux/index.md
@@ -67,4 +67,4 @@ toucan --help
 
 ## Compile from source
 
-For instructions on compiling from source, see [Compile from source](/docs/installation/compile-from-source/).
+For instructions on compiling from source, see [Compile from source](/docs/installation/source/).


### PR DESCRIPTION
The links under the Compile by Source section on the installation docs for macOS and Linux were leading to a [404 page](https://toucansites.com/docs/installation/compile-from-source/). Updated them to the current [source page](https://toucansites.com/docs/installation/source/).